### PR TITLE
Use English translations for JA and KO languages until the 2.1 version can be fully translated

### DIFF
--- a/questionnaire-ja.json
+++ b/questionnaire-ja.json
@@ -1,26 +1,26 @@
 {
   "specVersion": "2.1.0",
-  "language": "ja",
-  "title": "適合チェック質問一覧",
-  "contextText": "背景",
-  "questionsText": "質問",
-  "completedText": "終了しましたか？",
-  "statusText": "ステータス",
-  "answerColumnText": "回答",
-  "sectionColumnText": "セクション",
-  "numberColumnText": "番号",
-  "specRefColumnText": "仕様参考",
-  "questionColumnText": "質問本文",
-  "tocText": "目次",
-  "preambleText": "OpenChainプロジェクトは、オープンソースライセンスへのコンプライアンスをよりシンプルにし、一貫性を持たせることで、オープンソースに対する信頼を築きます。OpenChain仕様では、各品質コンプライアンスプログラムが満足すべき核となる要件を定義しています。OpenChainカリキュラムは、OpenChain仕様の必須要件を満たしながら、オープンソースプロセスやソリューションの教育的基礎を提供しています。企業は、OpenChain適合によって、こういった要件に適合していることを示すことができます。その結果、オープンソース・ライセンス・コンプライアンスがソフトウェアサプライチェーンの中にいる者にとって、より予測可能でわかりやすく、効率的なものになっています。\nこのドキュメントには企業がOpenChain適合がどうかを判断するための一連の質問が記載されています。すべての質問が「はい」だった場合、その企業はOpenChain仕様2.0版のすべての要件に適合していることになります。いくつかの質問に対する答えが「いいえ」だった場合、その企業はコンプライアンスプロセスの改善のために何が必要かを明確にすることができます。",
+  "language": "en",
+  "title": "Conformance in Questions",
+  "contextText": "Context",
+  "questionsText": "Questions",
+  "completedText": "Completed?",
+  "statusText": "Status",
+  "answerColumnText": "Answer",
+  "sectionColumnText": "Section",
+  "numberColumnText": "Number",
+  "specRefColumnText": "Spec Ref",
+  "questionColumnText": "Question Text",
+  "tocText": "Table of Contents",
+  "preambleText": "The OpenChain Project builds trust in open source by making license compliance simpler and more consistent. It maintains the OpenChain Specification to define a core set of requirements every quality compliance program must satisfy. The result is that open source license compliance becomes more predictable, understandable and efficient for participants of the software supply chain.\nThis document contains a series of questions to determine whether a company has an OpenChain Conformant program. If each of these questions can be answered with a \"yes\" then that company meets all the requirements of conformance to the OpenChain Specification version 2.1 (functionally identical to ISO/IEC DIS 5230:2020(e)). If any of the questions are answered with a \"no\" then the company can clearly identify where additional investment is needed to improve the compliance process.",
   "sections": [
     {
       "name": "Part 1",
-      "title": "1: オープンソースの責任を理解している",
+      "title": "1. Program foundation",
       "questions": [
         {
           "correctAnswer": "Yes",
-          "question": "（トレーニングや内部wiki、またはその他実用的な通信方法を通しての）供給ソフトウェア配信のオープンソースライセンスコンプライアンスについて規定しているポリシー文書を持っていますか？",
+          "question": "Do you have a documented policy governing the open source license compliance of the Supplied Software?",
           "number": "1.a",
           "type": "YES_NO",
           "specReference": [
@@ -30,26 +30,27 @@
         },
         {
           "correctAnswer": "Yes",
-          "question": "すべてのソフトウェアスタッフにオープンソースポリシーの存在を伝える手順書がありますか？",
+          "question": "Do you have a documented procedure to communicate the existence of the open source policy to all Software Staff",
           "number": "1.b",
           "type": "YES_NO",
           "specReference": [
+            "1.1",
             "1.1.2"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "プログラムの性能と有効性に影響のある役割とそれに対応する責任について明確にしていますか？",
+          "question": "Have you identified the roles and responsibilities that affect the performance and effectiveness of the Program?",
           "number": "1.c",
           "type": "YES_NO",
           "specReference": [
-		    "1.2",
+            "1.2",
             "1.2.1"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "各役割に必要な能力を特定し、文書化していますか？",
+          "question": "Have you identified and documented the competencies required for each role?",
           "number": "1.d",
           "type": "YES_NO",
           "specReference": [
@@ -59,7 +60,7 @@
         },
         {
           "correctAnswer": "Yes",
-          "question": "各プログラム参加者の能力を評価した証拠を文書化していますか？",
+          "question": "Have you documented the assessed competence for each Program participant?",
           "number": "1.e",
           "type": "YES_NO",
           "specReference": [
@@ -68,7 +69,7 @@
           ]
         },
         {
-          "question": "次のトピックに対する社員の意識を文書化していますか？",
+          "question": "Have you documented the awareness of your Program participants on the following topics?",
           "number": "1.f",
           "type": "SUBQUESTIONS",
           "specReference": [
@@ -79,7 +80,7 @@
           "subQuestions": {
             "1.f.i": {
               "correctAnswer": "Yes",
-              "question": "オープンソースポリシーとその場所",
+              "question": "The open source policy and where to find it;",
               "number": "1.f.i",
               "type": "YES_NO",
               "specReference": [
@@ -88,7 +89,7 @@
             },
             "1.f.ii": {
               "correctAnswer": "Yes",
-              "question": "関連するオープンソースの目的、",
+              "question": "Relevant open source objectives;",
               "number": "1.f.ii",
               "type": "YES_NO",
               "specReference": [
@@ -97,7 +98,7 @@
             },
             "1.f.iii": {
               "correctAnswer": "Yes",
-              "question": "プログラムを確実に有効なものにするために期待されるコントリビューション、",
+              "question": "Contributions expected to ensure the effectiveness of the Program;",
               "number": "1.f.iii",
               "type": "YES_NO",
               "specReference": [
@@ -106,7 +107,7 @@
             },
             "1.f.iv": {
               "correctAnswer": "Yes",
-              "question": "プログラム要件を満たすことができないことの影響",
+              "question": "The implications of failing to follow the Program requirements.",
               "number": "1.f.iv",
               "type": "YES_NO",
               "specReference": [
@@ -117,40 +118,31 @@
         },
         {
           "correctAnswer": "Yes",
-          "question": "プログラムの適用範囲の決定プロセスがありますか？",
+          "question": "Do you have a process for determining the scope of your Program?",
           "number": "1.g",
           "type": "YES_NO",
           "specReference": [
             "1.4",
-			"1.4.1"
+            "1.4.1"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "プログラムの適用範囲および制限を明確に定義した文書がありますか？",
+          "question": "Do you have a written statement clearly defining the scope and limits of the Program?",
           "number": "1.h",
           "type": "YES_NO",
           "specReference": [
             "1.4",
-			"1.4.1"
+            "1.4.1"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "オープンソースの義務、制約、権利を確認するプロセスがありますか？",
+          "question": "Do you have a documented procedure to review and document open source license obligations, restrictions and rights?",
           "number": "1.i",
           "type": "YES_NO",
           "specReference": [
             "1.5",
-            "1.5.1"
-          ]
-        },
-        {
-          "correctAnswer": "Yes",
-          "question": "義務、制約、権利を確認し、文書化する手順書がありますか？",
-          "number": "1.j",
-          "type": "YES_NO",
-          "specReference": [
             "1.5.1"
           ]
         }
@@ -158,11 +150,11 @@
     },
 	{
       "name": "Part 2",
-      "title": "2: コンプライアンスを履行するための責任者のアサイン",
+      "title": "2. Relevant tasks defined and supported",
       "questions": [
         {
           "correctAnswer": "Yes",
-          "question": "オープンソースコンプライアンスに関する外部からの問い合わせに対応する責任者（「オープンソース窓口」）を指名していますか？",
+          "question": "Have you assigned individual(s) responsibility for receiving external open source compliance inquiries?",
           "number": "2.a",
           "type": "YES_NO",
           "specReference": [
@@ -172,70 +164,71 @@
         },
         {
           "correctAnswer": "Yes",
-          "question": "オープンソース窓口機能が（たとえば電子メールアドレスやLinux Foundationオープン コンプライアンス ディレクトリを通じて）公的に明示されていますか？",
+          "question": "Is the external open source compliance contact publicly identified (e.g. via an email address or the Linux Foundation Open Compliance Directory)?",
           "number": "2.b",
           "type": "YES_NO",
           "specReference": [
             "2.1",
-			"2.1.1"
+            "2.1.1"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "オープンソースコンプライアンスの問い合わせを受けたり、問い合わせに答えたりする責任者を指名する手順書がありますか？",
+          "question": "Do you have a documented procedure for receiving and responding to open source compliance inquiries?",
           "number": "2.c",
           "type": "YES_NO",
           "specReference": [
             "2.1",
-			"2.1.2"
+            "2.1.2"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "特定されたプログラムの役割をサポートする人、グループ、または部署を文書化していますか？",
+          "question": "Have you documented the persons, group or function supporting the Program role(s) identified?",
           "number": "2.d",
           "type": "YES_NO",
           "specReference": [
             "2.1",
-			"2.2.1"
+            "2.2.1"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "特定されたプログラムの役割には、適切に人員が配置され、十分な予算が当てられていますか？",
+          "question": "Have the identified Program roles been properly staffed and adequately funded?",
           "number": "2.e",
           "type": "YES_NO",
           "specReference": [
             "2.1",
-			"2.2.2"
+            "2.2.2"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "組織内および組織外のオープンソースコンプライアンスに関する法律の専門家が特定されていますか？",
+          "question": "Has legal expertise to address internal and external open source compliance been identified?",
           "number": "2.f",
           "type": "YES_NO",
           "specReference": [
             "2.1",
-			"2.2.3"
+            "2.2.3"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "オープンソースコンプライアンスに関する組織内の責任者を指名する手順書がありますか？",
+          "question": "Do you have a documented procedure assigning internal responsibilities for open source compliance?",
           "number": "2.g",
           "type": "YES_NO",
           "specReference": [
             "2.1",
-			"2.2.4"
+            "2.2.4"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "不適合の場合のレビューや是正について扱う手順書がありますか？",
+          "question": "Do you have a documented procedure for handling review and remediation of non-compliant cases?",
           "number": "2.h",
           "type": "YES_NO",
           "specReference": [
+            "2.1",
             "2.2.5"
           ]
         }
@@ -243,41 +236,41 @@
     },
     {
       "name": "Part 3",
-      "title": "3: オープンソースコンテンツのレビューと承認",
+      "title": "3 Open source content review and approval",
       "questions": [
         {
           "correctAnswer": "Yes",
-          "question": "供給ソフトウェアのリリースに含まれるすべてのオープンソースコンポーネントに関する情報を特定し、追跡し、リストとして保管するための手順書がありますか？",
+          "question": "Do you have a documented procedure for identifying, tracking and archiving information about the open source components in a Supplied Software release?",
           "number": "3.a",
           "type": "YES_NO",
           "specReference": [
             "3.1",
-			"3.1.1"
+            "3.1.1"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "手順書に適切に従っていることを証明する、各供給ソフトウェアのリリースに関するオープンソースコンポーネントの記録がありますか？",
+          "question": "Do you have open source component records for the Supplied Software which demonstrate the documented procedure was properly followed?",
           "number": "3.b",
           "type": "YES_NO",
           "specReference": [
             "3.1",
-			"3.1.2"
+            "3.1.2"
           ]
         },
         {
-		  "question": "各供給ソフトウェアのリリースに関するオープンソースコンポーネントについて、少なくとも次の共通オープンソースライセンスのユースケースを扱った手順を実施していますか？",
+		  "question": "Do you have a documented procedure that covers these common open source license use cases for open source components in the Supplied Software?",
           "number": "3.c",
           "type": "SUBQUESTIONS",
           "specReference": [
             "3.2",
-			"3.2.1"
+            "3.2.1"
           ],
           "minNumberValidatedAnswers": 6,
           "subQuestions": {
             "3.c.i": {
               "correctAnswer": "Yes",
-              "question": "     バイナリ形態で頒布されている",
+              "question": "     Distribution in binary form;",
               "number": "3.c.i",
               "type": "YES_NO",
               "specReference": [
@@ -287,7 +280,7 @@
             },
             "3.c.ii": {
               "correctAnswer": "Yes",
-              "question": "     ソースコード形態で頒布されている",
+              "question": "     Distribution in source form;",
               "number": "3.c.ii",
               "type": "YES_NO",
               "specReference": [
@@ -297,7 +290,7 @@
             },
             "3.c.iii": {
               "correctAnswer": "Yes",
-              "question": "     コピーレフトの義務を生じうる他のオープンソースと統合されている",
+              "question": "     Integration with other open source that may trigger additional obligations;",
               "number": "3.c.iii",
               "type": "YES_NO",
               "specReference": [
@@ -307,7 +300,7 @@
             },
             "3.c.iv": {
               "correctAnswer": "Yes",
-              "question": "     改変されたオープンソースを含んでいる",
+              "question": "     Containing modified open source;",
               "number": "3.c.iv",
               "type": "YES_NO",
               "specReference": [
@@ -317,7 +310,7 @@
             },
             "3.c.v": {
               "correctAnswer": "Yes",
-              "question": "     供給ソフトウェア内の他のコンポーネントとやりとりする、両立性のないライセンス下のオープンソースやその他のソフトウェアを含んでいる",
+              "question": "     Containing open source or other software under incompatible licenses for interaction with other components in the Supplied Software;",
               "number": "3.c.v",
               "type": "YES_NO",
               "specReference": [
@@ -327,7 +320,7 @@
             },
             "3.c.vi": {
               "correctAnswer": "Yes",
-              "question": "     帰属要求のあるオープンソースを含んでいる",
+              "question": "     Containing open source with attribution requirements.",
               "number": "3.c.vi",
               "type": "YES_NO",
               "specReference": [
@@ -341,47 +334,47 @@
     },
     {
       "name": "Part 4",
-      "title": "4: オープンソースコンプライアンス関連資料の配布",
+      "title": "4. Compliance artifact creation and delivery",
       "questions": [
         {
           "correctAnswer": "Yes",
-          "question": "確認ライセンスの要求に基づいて、コンプライアンス関連資料が供給ソフトウェアとともに頒布されることを確実にするプロセスを説明した手順書がありますか？",
+          "question": "Do you have a documented procedure describing the process for ensuring the Compliance Artifacts are distributed with Supplied Software as required by the Identified Licenses?",
           "number": "4.a",
           "type": "YES_NO",
           "specReference": [
             "4.1",
-			"4.1.1"
+            "4.1.1"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "供給ソフトウェアに関する頒布コンプライアンス関連資料のコピーが保管されていますか？",
+          "question": "Do you have a documented procedure for archiving copies of Compliance Artifacts for the Supplied Software?",
           "number": "4.b",
           "type": "YES_NO",
           "specReference": [
             "4.1",
-			"4.1.2"
+            "4.1.2"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "コンプライアンス関連資料のコピーは、少なくとも供給ソフトウェアが提供され続けている期間、または確認ライセンスが要求する期間（いずれか長い方の期間）保管されていますか？",
+          "question": "Are the Compliance Artifacts archived at least as long as the Supplied Software is offered and as required by the Identified Licenses?",
           "number": "4.c",
           "type": "YES_NO",
           "specReference": [
             "4.1",
-			"4.1.2"
+            "4.1.2"
           ]
         }
       ]
     },
     {
       "name": "Part 5",
-      "title": "5: オープンソースコミュニティへの（積極的な）関わり方の理解",
+      "title": "5. Understanding open source community engagements",
       "questions": [
         {
           "correctAnswer": "Yes",
-          "question": "組織を代表してのオープンソースプロジェクトへのコントリビューションを管理するポリシーがありますか？",
+          "question": "Do you have a policy for contribution to open source projects on behalf of the organization?",
           "number": "5.a",
           "type": "YES_NO",
           "specReference": [
@@ -391,48 +384,48 @@
         },
         {
           "correctAnswer": "Yes",
-          "question": "オープンソースへのコントリビューションを管理する手順書がありますか？",
+          "question": "Do you have a documented procedure governing open source contributions?",
           "number": "5.b",
           "type": "YES_NO",
           "specReference": [
             "5.1",
-			"5.1.2"
+            "5.1.2"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "すべてのソフトウェアスタッフがオープンソース コントリビューション ポリシーの存在を認識できるような手順書がありますか？",
+          "question": "Do you have a documented procedure for making all Software Staff aware of the open source contribution policy?",
           "number": "5.c",
           "type": "YES_NO",
           "specReference": [
             "5.1",
-			"5.1.3"
+            "5.1.3"
           ]
         }
       ]
     },
     {
       "name": "Part 6",
-      "title": "6: 仕様要件への遵守",
+      "title": "6. Adherence to the specification requirements",
       "questions": [
         {
           "correctAnswer": "Yes",
-          "question": "プログラムが本仕様の全要件に適合していることを確認できる文書がありますか？",
+          "question": "Do you have documentation confirming that your Program meets all the requirements of this specification?",
           "number": "6.a",
           "type": "YES_NO",
           "specReference": [
             "6.1",
-			"6.1.1"
+            "6.1.1"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "プログラムの適合が過去18ヶ月内に見直されたことを確認できる文書がありますか？",
+          "question": "Do you have documentation confirming that your Program conformance was reviewed within the last 18 months?",
           "number": "6.b",
           "type": "YES_NO",
           "specReference": [
             "6.2",
-			"6.2.1"
+            "6.2.1"
           ]
         }
       ]

--- a/questionnaire-ko.json
+++ b/questionnaire-ko.json
@@ -1,26 +1,26 @@
 {
   "specVersion": "2.1.0",
-  "language": "ko",
-  "title": "준수 확인을 위한 질문",
-  "contextText": "배경",
-  "questionsText": "질문",
-  "completedText": "완료?",
-  "statusText": "상태",
-  "answerColumnText": "답변",
-  "sectionColumnText": "섹션",
-  "numberColumnText": "No",
-  "specRefColumnText": "설명서 Ref",
-  "questionColumnText": "질문 내용",
-  "tocText": "목차",
-  "preambleText": "OpenChain 프로젝트는 오픈소스 라이선스 컴플라이언스를 보다 간단하고 일관성있게 만들어 오픈소스에 대한 신뢰를 구축합니다. OpenChain 설명서는 모든 우수한 컴플라이언스 프로그램이 충족해야하는 핵심 요건을 정의합니다. OpenChain 커리큘럼은 OpenChain 설명서의 핵심 요구 사항을 충족하는 오픈 소스 프로세스 및 솔루션에 대한 교육 기반을 제공합니다. OpenChain 준수 확인을 통해 조직은 이러한 요건을 준수하고 있음을 나타낼 수 있습니다. 그 결과 소프트웨어 공급망의 참가자가 오픈소스 라이선스 컴플라이언스를 보다 예측 가능하고 이해하기 쉽고 효율적으로 만들 수 있습니다.\n이 문서에는 회사가 OpenChain을 준수하는지 여부를 확인하기위한 일련의 질문이 포함되어 있습니다. 이러한 각 질문에 \"예\"라고 대답 할 수 있으면 해당 회사는 OpenChain 설명서 버전 2.0에 대한 모든 요건을 충족합니다. 질문에 \"아니오\"라고 대답하면 회사는 컴플라이언스 프로세스를 개선하기 위해 추가 투자가 필요한 위치를 명확하게 식별 할 수 있습니다.",
+  "language": "en",
+  "title": "Conformance in Questions",
+  "contextText": "Context",
+  "questionsText": "Questions",
+  "completedText": "Completed?",
+  "statusText": "Status",
+  "answerColumnText": "Answer",
+  "sectionColumnText": "Section",
+  "numberColumnText": "Number",
+  "specRefColumnText": "Spec Ref",
+  "questionColumnText": "Question Text",
+  "tocText": "Table of Contents",
+  "preambleText": "The OpenChain Project builds trust in open source by making license compliance simpler and more consistent. It maintains the OpenChain Specification to define a core set of requirements every quality compliance program must satisfy. The result is that open source license compliance becomes more predictable, understandable and efficient for participants of the software supply chain.\nThis document contains a series of questions to determine whether a company has an OpenChain Conformant program. If each of these questions can be answered with a \"yes\" then that company meets all the requirements of conformance to the OpenChain Specification version 2.1 (functionally identical to ISO/IEC DIS 5230:2020(e)). If any of the questions are answered with a \"no\" then the company can clearly identify where additional investment is needed to improve the compliance process.",
   "sections": [
     {
       "name": "Part 1",
-      "title": "1. 프로그램 설립",
+      "title": "1. Program foundation",
       "questions": [
         {
           "correctAnswer": "Yes",
-          "question": "공급 대상 소프트웨어 배포에 대한 오픈소스 라이선스 컴플라이언스를 관리하는 문서화된 정책이 있습니까(예: 교육, 내부 위키 혹은 기타 실질적인 의사소통 방법)?",
+          "question": "Do you have a documented policy governing the open source license compliance of the Supplied Software?",
           "number": "1.a",
           "type": "YES_NO",
           "specReference": [
@@ -30,26 +30,27 @@
         },
         {
           "correctAnswer": "Yes",
-          "question": "오픈소스 정책의 존재를 모든 소프트웨어 공급 담당자에게 알리는 문서화된 절차가 있습니까?",
+          "question": "Do you have a documented procedure to communicate the existence of the open source policy to all Software Staff",
           "number": "1.b",
           "type": "YES_NO",
           "specReference": [
+            "1.1",
             "1.1.2"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "프로그램의 성능 및 효과에 영향을 미치는 역할 및 책임을 확인했습니까?",
+          "question": "Have you identified the roles and responsibilities that affect the performance and effectiveness of the Program?",
           "number": "1.c",
           "type": "YES_NO",
           "specReference": [
-		    "1.2",
+            "1.2",
             "1.2.1"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "각 역할에 필요한 역량을 확인하고 문서화했습니까?",
+          "question": "Have you identified and documented the competencies required for each role?",
           "number": "1.d",
           "type": "YES_NO",
           "specReference": [
@@ -59,7 +60,7 @@
         },
         {
           "correctAnswer": "Yes",
-          "question": "각 프로그램 참여자에 대해 역량을 평가한 증거를 문서화 했습니까?",
+          "question": "Have you documented the assessed competence for each Program participant?",
           "number": "1.e",
           "type": "YES_NO",
           "specReference": [
@@ -68,7 +69,7 @@
           ]
         },
         {
-          "question": "다음 주제에 대한 직원의 인지도를 문서화 한 증거가 있습니까?",
+          "question": "Have you documented the awareness of your Program participants on the following topics?",
           "number": "1.f",
           "type": "SUBQUESTIONS",
           "specReference": [
@@ -79,7 +80,7 @@
           "subQuestions": {
             "1.f.i": {
               "correctAnswer": "Yes",
-              "question": "오픈소스 정책 및 찾을 수 있는 위치,",
+              "question": "The open source policy and where to find it;",
               "number": "1.f.i",
               "type": "YES_NO",
               "specReference": [
@@ -88,7 +89,7 @@
             },
             "1.f.ii": {
               "correctAnswer": "Yes",
-              "question": "관련 오픈소스 목표,",
+              "question": "Relevant open source objectives;",
               "number": "1.f.ii",
               "type": "YES_NO",
               "specReference": [
@@ -97,7 +98,7 @@
             },
             "1.f.iii": {
               "correctAnswer": "Yes",
-              "question": "프로그램의 효과를 보장하기 위해 기대되는 기여,",
+              "question": "Contributions expected to ensure the effectiveness of the Program;",
               "number": "1.f.iii",
               "type": "YES_NO",
               "specReference": [
@@ -106,7 +107,7 @@
             },
             "1.f.iv": {
               "correctAnswer": "Yes",
-              "question": "프로그램 요건을 준수하지 않는 것의 의미,",
+              "question": "The implications of failing to follow the Program requirements.",
               "number": "1.f.iv",
               "type": "YES_NO",
               "specReference": [
@@ -117,40 +118,31 @@
         },
         {
           "correctAnswer": "Yes",
-          "question": "프로그램의 적용 범위를 결정하는 프로세스가 있습니까?",
+          "question": "Do you have a process for determining the scope of your Program?",
           "number": "1.g",
           "type": "YES_NO",
           "specReference": [
             "1.4",
-			"1.4.1"
-          ]
-        },
-        {
-          "correctAnswer": "Yes",
-          "question": "프로그램의 범위와 한계를 명확하게 정의한 서면 진술이 있습니까?",
-          "number": "1.h",
-          "type": "YES_NO",
-          "specReference": [
-		    "1.4",
             "1.4.1"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "오픈소스 라이선스 의무, 제한 및 권리를 검토하는 프로세스가 있습니까?",
-          "number": "1.i",
+          "question": "Do you have a written statement clearly defining the scope and limits of the Program?",
+          "number": "1.h",
           "type": "YES_NO",
           "specReference": [
-            "1.5",
-            "1.5.1"
+            "1.4",
+            "1.4.1"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "의무, 제한 및 권리를 검토하고 문서화하기 위한 문서화된 절차가 있습니까?",
-          "number": "1.j",
+          "question": "Do you have a documented procedure to review and document open source license obligations, restrictions and rights?",
+          "number": "1.i",
           "type": "YES_NO",
           "specReference": [
+            "1.5",
             "1.5.1"
           ]
         }
@@ -158,11 +150,11 @@
     },
 	{
       "name": "Part 2",
-      "title": "2. 관련 업무 정의 및 지원",
+      "title": "2. Relevant tasks defined and supported",
       "questions": [
         {
           "correctAnswer": "Yes",
-          "question": "외부 오픈소스 컴플라이언스 문의를 받는 담당자(오픈소스 연락담당자)를 지정했습니까?",
+          "question": "Have you assigned individual(s) responsibility for receiving external open source compliance inquiries?",
           "number": "2.a",
           "type": "YES_NO",
           "specReference": [
@@ -172,70 +164,71 @@
         },
         {
           "correctAnswer": "Yes",
-          "question": "오픈소스 연락 담당자 정보가 외부에 공개되어 있습니까(예: 이메일 주소 또는 Linux Foundation의 Open Compliance Directory)?",
+          "question": "Is the external open source compliance contact publicly identified (e.g. via an email address or the Linux Foundation Open Compliance Directory)?",
           "number": "2.b",
           "type": "YES_NO",
           "specReference": [
             "2.1",
-			"2.1.1"
+            "2.1.1"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "오픈소스 컴플라이언스 문의를 받고 대응하기 위한 책임을 부여하는 문서화된 절차가 있습니까?",
+          "question": "Do you have a documented procedure for receiving and responding to open source compliance inquiries?",
           "number": "2.c",
           "type": "YES_NO",
           "specReference": [
             "2.1",
-			"2.1.2"
+            "2.1.2"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "확인된 프로그램 역할을 지원하는 사람, 그룹 또는 기능을 문서화했습니까?",
+          "question": "Have you documented the persons, group or function supporting the Program role(s) identified?",
           "number": "2.d",
           "type": "YES_NO",
           "specReference": [
             "2.1",
-			"2.2.1"
+            "2.2.1"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "확인된 프로그램 역할에 적절하게 인원이 충원되었고 적합한 자금이 제공되었습니까?",
+          "question": "Have the identified Program roles been properly staffed and adequately funded?",
           "number": "2.e",
           "type": "YES_NO",
           "specReference": [
             "2.1",
-			"2.2.2"
+            "2.2.2"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "오픈소스 컴플라이언스와 관련된 내부 또는 외부의 법률 전문 지식을 이용할 수 있는 방법이 확인되었습니까?",
+          "question": "Has legal expertise to address internal and external open source compliance been identified?",
           "number": "2.f",
           "type": "YES_NO",
           "specReference": [
             "2.1",
-			"2.2.3"
+            "2.2.3"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "오픈소스 컴플라이언스에 대한 내부 책임을 할당하는 문서화된 절차가 있습니까?",
+          "question": "Do you have a documented procedure assigning internal responsibilities for open source compliance?",
           "number": "2.g",
           "type": "YES_NO",
           "specReference": [
             "2.1",
-			"2.2.4"
+            "2.2.4"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "미준수 사례의 검토 및 시정을 규정하는 문서화된 절차가 있습니까?",
+          "question": "Do you have a documented procedure for handling review and remediation of non-compliant cases?",
           "number": "2.h",
           "type": "YES_NO",
           "specReference": [
+            "2.1",
             "2.2.5"
           ]
         }
@@ -243,41 +236,41 @@
     },
     {
       "name": "Part 3",
-      "title": "3. 오픈소스 컨텐츠 검토 및 승인",
+      "title": "3 Open source content review and approval",
       "questions": [
         {
           "correctAnswer": "Yes",
-          "question": "공급 대상 소프트웨어를 구성하는 오픈소스 컴포넌트 모음에 대한 정보를 식별, 추적 및 보관하기 위한 문서화된 절차가 있습니까?",
+          "question": "Do you have a documented procedure for identifying, tracking and archiving information about the open source components in a Supplied Software release?",
           "number": "3.a",
           "type": "YES_NO",
           "specReference": [
             "3.1",
-			"3.1.1"
+            "3.1.1"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "공급 대상 소프트웨어 배포에 대해 문서화된 절차가 적절히 준수되었음을 입증하는 오픈소스 컴포넌트 기록이 있습니까?",
+          "question": "Do you have open source component records for the Supplied Software which demonstrate the documented procedure was properly followed?",
           "number": "3.b",
           "type": "YES_NO",
           "specReference": [
             "3.1",
-			"3.1.2"
+            "3.1.2"
           ]
         },
         {
-		  "question": "각 공급 대상 소프트웨어 배포의 오픈소스 컴포넌트에 대해 적어도 다음과 같은 일반적인 오픈소스 라이선스 사용 사례를 처리하는 절차를 구현했습니까?",
+		  "question": "Do you have a documented procedure that covers these common open source license use cases for open source components in the Supplied Software?",
           "number": "3.c",
           "type": "SUBQUESTIONS",
           "specReference": [
             "3.2",
-			"3.2.1"
+            "3.2.1"
           ],
           "minNumberValidatedAnswers": 6,
           "subQuestions": {
             "3.c.i": {
               "correctAnswer": "Yes",
-              "question": "     바이너리 형태로 배포;",
+              "question": "     Distribution in binary form;",
               "number": "3.c.i",
               "type": "YES_NO",
               "specReference": [
@@ -287,7 +280,7 @@
             },
             "3.c.ii": {
               "correctAnswer": "Yes",
-              "question": "     소스 형태로 배포;",
+              "question": "     Distribution in source form;",
               "number": "3.c.ii",
               "type": "YES_NO",
               "specReference": [
@@ -297,7 +290,7 @@
             },
             "3.c.iii": {
               "correctAnswer": "Yes",
-              "question": "     Copyleft 의무를 발생시킬 수 있는 다른 오픈 소스와 통합;",
+              "question": "     Integration with other open source that may trigger additional obligations;",
               "number": "3.c.iii",
               "type": "YES_NO",
               "specReference": [
@@ -307,7 +300,7 @@
             },
             "3.c.iv": {
               "correctAnswer": "Yes",
-              "question": "     수정한 오픈소스를 포함;",
+              "question": "     Containing modified open source;",
               "number": "3.c.iv",
               "type": "YES_NO",
               "specReference": [
@@ -317,7 +310,7 @@
             },
             "3.c.v": {
               "correctAnswer": "Yes",
-              "question": "     공급 대상 소프트웨어 내에서 상호 작용하는 다른 컴포넌트와 호환되지 않는 라이선스 하의 오픈소스 또는 기타 소프트웨어를 포함;",
+              "question": "     Containing open source or other software under incompatible licenses for interaction with other components in the Supplied Software;",
               "number": "3.c.v",
               "type": "YES_NO",
               "specReference": [
@@ -327,7 +320,7 @@
             },
             "3.c.vi": {
               "correctAnswer": "Yes",
-              "question": "     저작자 표시 요건이 있는 오픈소스를 포함.",
+              "question": "     Containing open source with attribution requirements.",
               "number": "3.c.vi",
               "type": "YES_NO",
               "specReference": [
@@ -341,47 +334,47 @@
     },
     {
       "name": "Part 4",
-      "title": "4. 컴플라이언스 결과물 생성 및 전달",
+      "title": "4. Compliance artifact creation and delivery",
       "questions": [
         {
           "correctAnswer": "Yes",
-          "question": "식별된 라이선스에서 요구하는대로 컴플라이언스 결과물을 공급 대상 소프트웨어와 함께 배포하기 위한 프로세스를 설명하는 문서화된 절차가 있습니까?",
+          "question": "Do you have a documented procedure describing the process for ensuring the Compliance Artifacts are distributed with Supplied Software as required by the Identified Licenses?",
           "number": "4.a",
           "type": "YES_NO",
           "specReference": [
             "4.1",
-			"4.1.1"
+            "4.1.1"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "공급 대상 소프트웨어의 컴플라이언스 결과물 사본을 보관합니까?",
+          "question": "Do you have a documented procedure for archiving copies of Compliance Artifacts for the Supplied Software?",
           "number": "4.b",
           "type": "YES_NO",
           "specReference": [
             "4.1",
-			"4.1.2"
+            "4.1.2"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "컴플라이언스 결과물 사본은 적어도 공급 대상 소프트웨어가 제공되는 중이거나 식별된 라이선스가 요구하는 기간 중 더 긴 시간 동안 보관됩니까?",
+          "question": "Are the Compliance Artifacts archived at least as long as the Supplied Software is offered and as required by the Identified Licenses?",
           "number": "4.c",
           "type": "YES_NO",
           "specReference": [
             "4.1",
-			"4.1.2"
+            "4.1.2"
           ]
         }
       ]
     },
     {
       "name": "Part 5",
-      "title": "5. 오픈소스 커뮤니티 참여에 대한 이해",
+      "title": "5. Understanding open source community engagements",
       "questions": [
         {
           "correctAnswer": "Yes",
-          "question": "조직을 대신하여 오픈소스 프로젝트에 기여하는 것을 관리하는 정책이 있습니까?",
+          "question": "Do you have a policy for contribution to open source projects on behalf of the organization?",
           "number": "5.a",
           "type": "YES_NO",
           "specReference": [
@@ -391,48 +384,48 @@
         },
         {
           "correctAnswer": "Yes",
-          "question": "오픈소스 기여를 관리하는 문서화된 절차가 있습니까?",
+          "question": "Do you have a documented procedure governing open source contributions?",
           "number": "5.b",
           "type": "YES_NO",
           "specReference": [
             "5.1",
-			"5.1.2"
+            "5.1.2"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "모든 소프트웨어 공급 담당자가 오픈소스 기여 정책의 존재를 인식하도록 하는 문서화된 절차가 있습니까?",
+          "question": "Do you have a documented procedure for making all Software Staff aware of the open source contribution policy?",
           "number": "5.c",
           "type": "YES_NO",
           "specReference": [
             "5.1",
-			"5.1.3"
+            "5.1.3"
           ]
         }
       ]
     },
     {
       "name": "Part 6",
-      "title": "6. 설명서 요건 준수",
+      "title": "6. Adherence to the specification requirements",
       "questions": [
         {
           "correctAnswer": "Yes",
-          "question": "프로그램이 이 설명서의 모든 요구사항을 충족함을 확인하는 문서가 있습니까?",
+          "question": "Do you have documentation confirming that your Program meets all the requirements of this specification?",
           "number": "6.a",
           "type": "YES_NO",
           "specReference": [
             "6.1",
-			"6.1.1"
+            "6.1.1"
           ]
         },
         {
           "correctAnswer": "Yes",
-          "question": "지난 18개월 이내에 프로그램 준수가 검토 되었음을 확인하는 문서가 있습니까?",
+          "question": "Do you have documentation confirming that your Program conformance was reviewed within the last 18 months?",
           "number": "6.b",
           "type": "YES_NO",
           "specReference": [
             "6.2",
-			"6.2.1"
+            "6.2.1"
           ]
         }
       ]


### PR DESCRIPTION
Since the 2.1 updates have not been fully translated into Japanese and Korean, use the English version.

Once the translations are complete, we will replace these with the fully translated versions.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>